### PR TITLE
SGRID: detect endianness at runtime

### DIFF
--- a/dist/endian.patch
+++ b/dist/endian.patch
@@ -1,0 +1,52 @@
+diff -x*~ -ur sgrid.orig/src/main/main/endianIO.c sgrid/src/main/main/endianIO.c
+--- sgrid.orig/src/main/main/endianIO.c	2023-10-19 18:58:52
++++ sgrid/src/main/main/endianIO.c	2023-12-24 09:08:01
+@@ -3,17 +3,11 @@
+ 
+ #include "sgrid.h"
+ 
+-/* About binary formats:
+-   There exists /usr/include/endian.h, but how standard is this?
+-   also see /usr/include/byteswap.h, which does not do 8 bytes for non-gcc?
+-   see include/bits/byteswap.h for gcc/x86 optimized code
+-*/
+-#include <endian.h>
+-#if  __BYTE_ORDER == __LITTLE_ENDIAN
+-#define BYTE_ORDER_LITTLE 1
+-#else
+-#define BYTE_ORDER_LITTLE 0
+-#endif
++static inline char get_byte_order(void) {
++  const short order = 1;
++  return *(char*)&order;
++}
++#define BYTE_ORDER_LITTLE get_byte_order()
+ 
+ 
+ /* use fwrite to write an array of doubles to a file in little endian format */
+diff -x*~ -ur sgrid.orig/src/utility/output/VTK_out.c sgrid/src/utility/output/VTK_out.c
+--- sgrid.orig/src/utility/output/VTK_out.c	2023-10-19 18:58:52
++++ sgrid/src/utility/output/VTK_out.c	2023-12-24 09:08:21
+@@ -11,17 +11,12 @@
+    The VTK lagacy data format used here is by default big endian binary data.
+    This used to be the default on "workstations", while x86 "PCs"
+    typically use little endian.
+-
+-   There exists /usr/include/endian.h, but how standard is this?
+-   also see /usr/include/byteswap.h, which does not do 8 bytes for non-gcc?
+-   see include/bits/byteswap.h for gcc/x86 optimized code
+ */
+-#include <endian.h>
+-#if  __BYTE_ORDER == __LITTLE_ENDIAN
+-#define BYTE_ORDER_LITTLE 1
+-#else
+-#define BYTE_ORDER_LITTLE 0
+-#endif
++static inline char get_byte_order(void) {
++  const short order = 1;
++  return *(char*)&order;
++}
++#define BYTE_ORDER_LITTLE get_byte_order()
+ 
+ 
+ /* in 3d and 2d it usually comes down to this: write numbers 

--- a/src/build.sh
+++ b/src/build.sh
@@ -49,7 +49,7 @@ echo "SGRID: Unpacking archive..."
 pushd ${BUILD_DIR}
 ${TAR?} xf ${SRCDIR}/../dist/${NAME}.tar
 pushd ${NAME}
-#${PATCH?} -p1 < ${SRCDIR}/../dist/stdarg.patch
+${PATCH?} -p1 < ${SRCDIR}/../dist/endian.patch
 # Some (ancient but still used) versions of patch don't support the
 # patch format used here but also don't report an error using the exit
 # code. So we use this patch to test for this


### PR DESCRIPTION
this avoids using a non-standard include file that does not exist on macOS. At also avoid trying to use Cactus' configure output (which also detects endianess) which is awkward since it pulls in lots of Cactus include files. 